### PR TITLE
feat:增加登录的前后端交互

### DIFF
--- a/server/water-order-backend/controllers/loginCtrl.js
+++ b/server/water-order-backend/controllers/loginCtrl.js
@@ -1,14 +1,34 @@
+const SQL = require('../utils/sql');
+
 const login = {
-  userLogin: (res, req) => {
+  loginWithAccount: (res, req) => {
     const userName = res.body.userName;
     const userPass = res.body.userPass;
     console.log('接收到用户登录请求了！');
     console.log('userName:', userName);
     console.log('userPass:', userPass);
-    req.send({message:'通信成功！'})
-  },
 
-  logUser: (res, req) => {},
+    const sql = `
+      SELECT *
+      FROM USER
+      WHERE USERNAME = '${userName}' AND USERPASS = '${userPass}' 
+    `;
+
+    SQL.createSQL(sql, [], (err, data) => {
+      if (data.length) {
+        req.send({
+          success: true,
+          data,
+        });
+      } else {
+        req.json(400, {
+          success: false,
+          data: '登陆失败，用户名或密码错误！',
+          error: err,
+        });
+      }
+    });
+  },
 };
 
 module.exports = login;

--- a/server/water-order-backend/routes/login.js
+++ b/server/water-order-backend/routes/login.js
@@ -2,6 +2,6 @@ var express = require('express');
 var router = express.Router();
 const ctrl = require('../controllers/loginCtrl');
 
-router.post('/', ctrl.userLogin);
+router.post('/account', ctrl.loginWithAccount);
 
 module.exports = router;

--- a/server/water-order-backend/utils/sql.js
+++ b/server/water-order-backend/utils/sql.js
@@ -1,14 +1,5 @@
 const mysqlDB = require('mysql');
 
-//数据库配置信息
-const db = mysqlDB.createConnection({
-  host: 'localhost',
-  port: '3306',
-  user: 'root',
-  password: 'raino123',
-  database: 'water_order',
-});
-
 //自定义封装的SQL方法，后续可以再进一步封装
 const SQL = {
   /**
@@ -19,7 +10,14 @@ const SQL = {
    */
   createSQL: (sql, params, callback) => {
     console.log('进入数据库操作');
-
+    //数据库配置信息
+    const db = mysqlDB.createConnection({
+      host: 'localhost',
+      port: '3306',
+      user: 'root',
+      password: 'raino123',
+      database: 'water_order',
+    });
     db.connect();
     db.query(sql, params, callback);
     db.end();

--- a/src/libs/Header/components/Avatar.tsx
+++ b/src/libs/Header/components/Avatar.tsx
@@ -1,20 +1,51 @@
-import { Avatar, Divider, Space } from "antd";
-import React from "react";
-import styles from "../styles/index.module.scss";
-import { UserOutlined } from "@ant-design/icons";
-import { Link } from "react-router-dom";
+import { Avatar, Divider, Space } from 'antd';
+import React, { useMemo, useState } from 'react';
+import styles from '../styles/index.module.scss';
+import { UserOutlined } from '@ant-design/icons';
+import LoginModal from '../../LoginModal';
+import { authStore } from '../../../store/AuthStore/authStore';
+import { observer } from 'mobx-react';
 
 const IndexAvatar = () => {
-  return (
-    <Space className={styles.avatar} size={20}>
-      <div>
-        <a className={styles.loginLink}>登录</a>
+  const [visible, setVisible] = useState<boolean>(false);
+
+  const loginLink = () => {
+    if (authStore.isLogin)
+      return (
+        <Space size="middle" align="baseline">
+          <span>
+            欢迎,亲爱的<a>{authStore.user.userRealName}</a>
+          </span>
+          <a className={styles.loginLink} onClick={() => authStore.setLoginOut()}>
+            退出登录
+          </a>
+        </Space>
+      );
+    return (
+      <>
+        <a className={styles.loginLink} onClick={() => setVisible(true)}>
+          登录
+        </a>
         <Divider type="vertical" />
         <a className={styles.loginLink}>注册</a>
-      </div>
-      <Avatar style={{ backgroundColor: "#87d068" }} icon={<UserOutlined />} />
-    </Space>
+      </>
+    );
+  };
+
+  return (
+    <React.Fragment>
+      <Space className={styles.avatar} size={20}>
+        <div>{loginLink()}</div>
+        <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} />
+      </Space>
+      <LoginModal
+        visible={visible}
+        onChange={(status: boolean) => {
+          setVisible(status);
+        }}
+      />
+    </React.Fragment>
   );
 };
 
-export default IndexAvatar;
+export default observer(IndexAvatar);

--- a/src/pages/Login/components/description.tsx
+++ b/src/pages/Login/components/description.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import styles from '../styles/index.module.scss';
 import waterMan from '../images/diliverWaterMan.png';
 import LoginModal from '../../../libs/LoginModal';
+import { authStore } from '../../../store/AuthStore/authStore';
+import { observer } from 'mobx-react-lite';
 
 const LoginContentDescription = () => {
   const [visible, setVisible] = useState<boolean>(false);
@@ -15,20 +17,46 @@ const LoginContentDescription = () => {
             Water Order <span style={{ fontSize: 95, color: '#ff575f' }}>Online</span>
           </h1>
           <h3 className={styles.secTitle}>基于React实现的便捷网上订水系统，为您的地区定制</h3>
-          <Button
-            type="primary"
-            danger
-            size="large"
-            className={styles.loginButton}
-            onClick={() => {
-              setVisible(true);
-            }}
-          >
-            立即登录
-          </Button>
-          <Button type="default" danger size="large" className={styles.loginButton}>
-            游客浏览
-          </Button>
+          {authStore.isLogin && (
+            <>
+              <Button
+                type="primary"
+                size="large"
+                danger
+                className={styles.loginButton}
+                onClick={() => authStore.setLoginOut()}
+              >
+                进入首页
+              </Button>
+              <Button
+                type="default"
+                danger
+                size="large"
+                className={styles.loginButton}
+                onClick={() => authStore.setLoginOut()}
+              >
+                退出登录
+              </Button>
+            </>
+          )}
+          {!authStore.isLogin && (
+            <>
+              <Button
+                type="primary"
+                danger
+                size="large"
+                className={styles.loginButton}
+                onClick={() => {
+                  setVisible(true);
+                }}
+              >
+                立即登录
+              </Button>
+              <Button type="default" danger size="large" className={styles.loginButton}>
+                游客浏览
+              </Button>
+            </>
+          )}
         </div>
         <div className={styles.waterMan}>
           <img
@@ -49,4 +77,4 @@ const LoginContentDescription = () => {
   );
 };
 
-export default LoginContentDescription;
+export default observer(LoginContentDescription);

--- a/src/store/AuthStore/authStore.ts
+++ b/src/store/AuthStore/authStore.ts
@@ -1,3 +1,4 @@
+import { Modal } from 'antd';
 import { observable, action, makeObservable } from 'mobx';
 import { TUser } from './interface';
 
@@ -20,7 +21,16 @@ class AuthStore {
   };
 
   @action setLoginOut = () => {
-    this.isLogin = false;
+    Modal.confirm({
+      title: '退出登录',
+      content: '确定要退出登录？',
+      onOk: () => {
+        this.isLogin = false;
+      },
+      okText: '立刻登出',
+      cancelText: '取消',
+      centered: true,
+    });
   };
 
   @action setRemenber = () => {

--- a/src/store/AuthStore/interface/index.ts
+++ b/src/store/AuthStore/interface/index.ts
@@ -1,8 +1,10 @@
 export type TUser = {
   userName?: string;
   phone?: string;
-  realName?: string;
+  userRealName?: string;
   nickName?: string;
   email?: string;
   address?: string;
+  uid?: string;
+  userPass?: string;
 };


### PR DESCRIPTION
# 功能增加：登录页
### 前端相关
- 修改登录页按钮及头像旁边登录链接的UI互动，使其可以根据登录状态变化UI
- 修改用户权限中心authStore相关状态管理

### 后端相关
- 增加Login页面的数据库比对
- 修改SQL.createSQL逻辑，让每次sql操作都执行一次createConnect，解决了多次请求会crash的情况

### 后续工作
- 增加token验证，让用户不用每次刷新页面都需要重新登录
- 增加注册相关功能
- 增加忘记密码相关功能
- 增加头像
- 增加密码MD5加密
- 增加UUID的存储
- 增加手机验证码登录功能